### PR TITLE
43-erreurs-dans-code-inutilisé

### DIFF
--- a/STM32/app/inc/appSX1272.h
+++ b/STM32/app/inc/appSX1272.h
@@ -39,7 +39,5 @@
 #define WaitRxMax 10000 //en ms
 
 void APP_SX1272_setup();
-void APP_SX1272_runTransmit();
-void APP_SX1272_runReceive();
 
 #endif /* APP_INC_APPSX1272_H_ */


### PR DESCRIPTION
Suppression de code qui génère des warnings à la compilation alors qu'il est inutilisé (appSX1272 transmit et receive)